### PR TITLE
updated datasets

### DIFF
--- a/cleaning/.ipynb_checkpoints/clean_datasets-checkpoint.ipynb
+++ b/cleaning/.ipynb_checkpoints/clean_datasets-checkpoint.ipynb
@@ -1,0 +1,44 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open('../datasets.json') as json_file:\n",
+    "    data = json.load(json_file)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/cleaning/clean_datasets.ipynb
+++ b/cleaning/clean_datasets.ipynb
@@ -1,0 +1,94 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open('../datasets.json') as json_file:\n",
+    "    datasets = json.load(json_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_providers = [d['data_provider'] for d in datasets]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fail_list = []\n",
+    "for d in datasets:\n",
+    "    try:\n",
+    "        d['data_provider']\n",
+    "    except:\n",
+    "        fail_list.append(d)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fail_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/datasets.json
+++ b/datasets.json
@@ -2655,85 +2655,6 @@
     }
   },
   {
-    "title": "Program model information from NYC",
-    "geography": "NY",
-    "alias": [
-      "Program model information from New York City"
-    ],
-    "dataset_id": "dataset-b0b87685ee1f9f987533",
-    "dataset_id_metadata": {
-      "dataset_id": "dataset-b0b87685ee1f9f987533",
-      "hashed_columns": [
-        "title"
-      ],
-      "date_created": "2019-09-01"
-    }
-  },
-  {
-    "title": "Program model information from Philadelphia",
-    "geography": "PA",
-    "dataset_id": "dataset-36a330ced0080d528431",
-    "dataset_id_metadata": {
-      "dataset_id": "dataset-36a330ced0080d528431",
-      "hashed_columns": [
-        "title"
-      ],
-      "date_created": "2019-09-01"
-    }
-  },
-  {
-    "title": "Program model information from Hennepin County",
-    "geography": "MN",
-    "alias": [
-      "Program model information from Minneapolis",
-      "Program model information from Twin Cities"
-    ],
-    "dataset_id": "dataset-f79a30291485aa9e6ecb",
-    "dataset_id_metadata": {
-      "dataset_id": "dataset-f79a30291485aa9e6ecb",
-      "hashed_columns": [
-        "title"
-      ],
-      "date_created": "2019-09-01"
-    }
-  },
-  {
-    "title": "Program model information from Nebraska",
-    "geography": "NE",
-    "dataset_id": "dataset-6905ebdfa3967f27a2c3",
-    "dataset_id_metadata": {
-      "dataset_id": "dataset-6905ebdfa3967f27a2c3",
-      "hashed_columns": [
-        "title"
-      ],
-      "date_created": "2019-09-01"
-    }
-  },
-  {
-    "title": "Program model information from New Jersey",
-    "geography": "NJ",
-    "dataset_id": "dataset-b9f272903cd17a3ea153",
-    "dataset_id_metadata": {
-      "dataset_id": "dataset-b9f272903cd17a3ea153",
-      "hashed_columns": [
-        "title"
-      ],
-      "date_created": "2019-09-01"
-    }
-  },
-  {
-    "title": "Program model information from Rhode Island",
-    "geography": "RI",
-    "dataset_id": "dataset-18b40bfb269dfbd09981",
-    "dataset_id_metadata": {
-      "dataset_id": "dataset-18b40bfb269dfbd09981",
-      "hashed_columns": [
-        "title"
-      ],
-      "date_created": "2019-09-01"
-    }
-  },
-  {
     "title": "Temporary Assistance for Needy Families",
     "data_provider": "Health and Human Services",
     "geography": "PA",
@@ -2936,8 +2857,8 @@
     }
   },
   {
-    "title": "Exit survey",
-    "geography": "OH",
+    "title": "TANF Exit survey",
+    "data_provider":"Health and Human Services",
     "alias": [
       "Exit survey data"
     ],
@@ -3341,6 +3262,7 @@
   },
   {
     "title": "Devolution and Urban Change",
+    "data_provider": "MDRC",
     "geography": "FL",
     "dataset_id": "dataset-6f80f8ea96fd5734778e",
     "dataset_id_metadata": {


### PR DESCRIPTION
deleted items like the below because they are just a subset of TANF data.
```
{
    "title": "Program model information from NYC",
    "geography": "NY",
    "alias": [
      "Program model information from New York City"
    ],
    "dataset_id": "dataset-b0b87685ee1f9f987533",
    "dataset_id_metadata": {
      "dataset_id": "dataset-b0b87685ee1f9f987533",
      "hashed_columns": [
        "title"
      ],
      "date_created": "2019-09-01"
    }
  }

```

and added data_provider to one dataset that did not have one. now all entries in `datasets.json` have `data_providers`.
  