### PR TITLE
datasets from usda endnote document

### DIFF
--- a/datasets.json
+++ b/datasets.json
@@ -3,12 +3,19 @@
         "id": "dataset-001",
         "provider": "IRI",
         "title": "IRI Infoscan",
+        "alt_title": [
+            "retail scanner data"
+        ],
         "url": "https://www.iriworldwide.com/en-US/Solutions/Retail"
     },
     {
         "id": "dataset-002",
         "provider": "IRI",
         "title": "IRI Consumer Network",
+        "alt_title": [
+            "Consumer Network",
+            "household scanner data"
+        ],
         "url": "https://www.iriworldwide.com/en-US/Solutions/Media/Media-Solutions/Consumer"
     },
     {
@@ -490,7 +497,39 @@
         ],
         "url": "https://www.ers.usda.gov/data-products/food-security-in-the-united-states/documentation.aspx#cps",
         "description": "The Current Population Survey Food Security Supplement (CPS-FSS) is the source of national and State-level statistics on food insecurity used in USDA's annual reports on household food security."
+    },
+    {
+        "id": "dataset-048",
+        "provider": "U.S. Department of Agriculture",
+        "title": "Food Security Questionnaire",
+        "alt_title": [
+           "NHANES-FSQ",
+           "FSQ",
+           "CPS-FSQ"
+        ],
+        "url": "https://wwwn.cdc.gov/Nchs/Nhanes/2013-2014/FSQ_H.htm",
+        "description": "The Current Population Survey Food Security Supplement (CPS-FSS) is the source of national and State-level statistics on food insecurity used in USDA's annual reports on household food security."
+    },
+    {
+        "id": "dataset-049",
+        "provider": "U.S. Department of Agriculture",
+        "title": "Food Security Survey Module",
+        "alt_title": [
+           "FSSM"
+        ],
+        "url": "https://www.ers.usda.gov/media/8279/ad2012.pdf",
+        "description": "https://www.ers.usda.gov/topics/food-nutrition-assistance/food-security-in-the-us/survey-tools.aspx#household."
+    },
+    {
+        "id": "dataset-050",
+        "provider":"Centers for Disease Control and Prevention",
+        "title": "National Health Interview Survey Family Food Security Supplement",
+        "alt_title": [
+           "NHIS-FFS",
+           "NHIS"
+        ],
+        "url": "https://www.cdc.gov/nchs/nhis/about_nhis.htm",
+        "description": " The Family Food Security (FFS) section, sponsored by the United States Department of Agriculture (USDA), consists of 10 questions addressing adult 30-day food security. The purpose of the questions is to examine the relationship between health and food insecurity."
     }
     
 ]
-    


### PR DESCRIPTION
`dataset-048` 
This is the `Food Security Questionnaire` - this is a supplemental survey to NHANES, CPS and others, but it's unclear to me whether it's the same exact questionnaire. I'm adding it because it's listed in USDA's crosswalk https://github.com/NYU-CI/RichContextMetadata/blob/master/metadata/20190920_usda_endnote/Output%20Tracking%20FAQs.docx. "CPS-NHANES" and "CPS-FSQ" were both added to `alt_title`.

See:
https://www.ers.usda.gov/topics/food-nutrition-assistance/food-security-in-the-us/history-background/ (CPS use of FSQ)
https://cps.ipums.org/cps/food_security_sample_notes.shtml  (CPS use of FSQ)
https://wwwn.cdc.gov/Nchs/Nhanes/2005-2006/FSQ_D.htm (NHANES use of FSQ)

For this record, I set `data_provider` to USDA since it looks like USDA authored the survey; and, given that it shows up in NHANES and CPS which are administered by different bureaus, USDA was the common denominator.

In terms of searching,  both  "food security questionnaire"  and  "food security questionnaire" NHANES resulted in overlapping titles in Pubmed (neither returned anything in dimensions), so I thought it merited its own entry in `datasets.json`.

Conflict:
Existing `dataset-033`, `Current Population Survey Food Security Supplement`. I'm guessing the Food Security Supplement is a result of the Food Security Questionnaire?

The Current Population Survey (CPS) currently does not have it's own entry - it has two related entries, the second of which seems to conflict with our new `dataset-048` 
```
{
        "id": "dataset-047",
        "provider": "U.S. Census Bureau",
        "title": "Current Population Survey Annual Social and Economic Supplement",
        "alt_title": [
           "CPS-ASEC",
           "CPS",
           "ASEC"
        ],
        "url": "https://www.ers.usda.gov/data-products/food-security-in-the-united-states/documentation.aspx#cps",
        "description": "The Current Population Survey Food Security Supplement (CPS-FSS) is the source of national and State-level statistics on food insecurity used in USDA's annual reports on household food security."
    }
```
and 
```
{
        "id": "dataset-033",
        "provider": "U.S. Census Bureau",
        "title": "Current Population Survey Food Security Supplement",
        "alt_title": [
           "CPS-FSS",
           "CPS",
           "FSS"
        ],
        "url": "https://www.ers.usda.gov/data-products/food-security-in-the-united-states/documentation.aspx#cps",
        "description": "The Current Population Survey Food Security Supplement (CPS-FSS) is the source of national and State-level statistics on food insecurity used in USDA's annual reports on household food security."
    }
```
I see a few options for moving forward:

1. create 'Current population survey' as its own entry the way 'NHANES' has its own, and create a new metadata field `sub_modules` or `parent_survey`, and create entries for 'FSQ', 'ASEC' etc. Since FSQ also appears in NHANES so we'd add that as a submodule to the existing entry.
2. Create  equivalents of "Current Population Survey Food Security Supplement" for all permutations of these. so we'd have 
"NHANES Food Security Supplement" as well.


`dataset-049` - Family Food Security Supplement. 
FSQ (dataset-048) *may* be a submodule of FSSM (dataset-049). It's mentioned here:

it also appears that the FSSM is used in other surveys see 
https://wwwn.cdc.gov/Nchs/Nhanes/1999-2000/FSQ.htm

> The 18-item module, formerly known as the "Core food security module" was administered to one adult in a household, even if there was more than one family in the household. The questions referred to all household members, even if they were not individual participants in NHANES. The FSSM has been used on many other surveys, including the Current Population Survey (CPS), whose results are used to provide an estimate of the percent of US households that is food insecure and that experiences hunger.


Also see `dataset-050`, "National Health Interview Survey Family Food Security Supplement"
the Family Food Security (FFS) is a supplement to the National Health Interview Survey (NHIS).
I listed it as one dataset instead of a submodule. I also did not list FFS as an alias as that would return many results for 'Fee-For-Service.' I also included the url for the main NHIS documentation; I searched for documentation on this specific submodule, but mainly found pdfs (ftp://ftp.cdc.gov/pub/Health_Statistics/NCHS/Dataset_Documentation/NHIS/2016/srvydesc.pdf), and research papers that listed them together.