### PR TITLE
moar unit tests

### DIFF
--- a/datasets.json
+++ b/datasets.json
@@ -1573,7 +1573,7 @@
     {
         "id": "dataset-143",
         "provider": "U.S. Bureau of Labor Statistics",
-        "title": " National Longitudinal Survey of Youth",
+        "title": "National Longitudinal Survey of Youth",
         "alt_title": [
             "NLSY",
             "NLSY-CS"
@@ -1659,13 +1659,13 @@
         "id": "dataset-151",
         "provider": "Oregon Department of Corrections",
         "title": "Community Supervision Data",
-        "alt_title":[
+        "alt_title": [
             "parole data",
             "post prison supervision data",
             "post-prison supervision data"
         ],
         "url": "https://www.oregon.gov/doc/research-and-requests/pages/research-and-statistics.aspx",
-        "description": "The Oregon Department of Corrections’ (DOC) Research and Evaluation division provides mission-critical information on offender populations, program performance, and policy impact."
+        "description": "The Oregon Department of Corrections\u2019 (DOC) Research and Evaluation division provides mission-critical information on offender populations, program performance, and policy impact."
     },
     {
         "id": "dataset-152",
@@ -1677,7 +1677,7 @@
         "id": "dataset-153",
         "provider": "U.S. Department of Housing and Urban Development",
         "title": "moving to opportunity program data",
-        "alt_title":[
+        "alt_title": [
             "MTO Data"
         ],
         "url": "https://www.hud.gov/programdescription/mto",
@@ -1687,13 +1687,13 @@
         "id": "dataset-154",
         "provider": "Oregon Department of Corrections",
         "title": "decision support system",
-        "alt_title":[
+        "alt_title": [
             "DDS",
             "DDS-Justice",
             "decision support system - justice"
         ],
         "url": "https://www.oregon.gov/doc/research-and-requests/Pages/research-and-statistics.aspx",
-        "description": "Decision Support System – Justice, which contains integrated, individual-level data from law enforcement agencies (Portland Police Departments and the Multnomah County Sheriff), the District Attorney, and the Courts. "
+        "description": "Decision Support System \u2013 Justice, which contains integrated, individual-level data from law enforcement agencies (Portland Police Departments and the Multnomah County Sheriff), the District Attorney, and the Courts. "
     },
     {
         "id": "dataset-155",
@@ -1768,18 +1768,18 @@
         "id": "dataset-161",
         "provider": "Federal Bureau of Investigation",
         "title": "Uniform Crime Report",
-        "alt_title":[
+        "alt_title": [
             "UCR",
             "FBI Uniform Crime Report"
         ],
         "url": "https://www.fbi.gov/services/cjis/ucr",
-        "description": "Decision Support System – Justice, which contains integrated, individual-level data from law enforcement agencies (Portland Police Departments and the Multnomah County Sheriff), the District Attorney, and the Courts. "
+        "description": "Decision Support System \u2013 Justice, which contains integrated, individual-level data from law enforcement agencies (Portland Police Departments and the Multnomah County Sheriff), the District Attorney, and the Courts. "
     },
     {
         "id": "dataset-162",
         "provider": "Maryland Department of Juvenile Services",
         "title": "Maryland Department of Juvenile Services Data",
-        "alt_title":[
+        "alt_title": [
             "DJJ data",
             "Maryland DJJ Data"
         ],
@@ -1789,7 +1789,7 @@
         "id": "dataset-163",
         "provider": "Massachusetts Department of Criminal Justice Information Services",
         "title": "Massachusetts Criminal Offender Record Information",
-        "alt_title":[
+        "alt_title": [
             "CORI",
             "CORI Data"
         ],
@@ -1800,7 +1800,7 @@
         "id": "dataset-164",
         "provider": "Boston Police Department",
         "title": "Boston Police Department Data",
-        "alt_title":[
+        "alt_title": [
             "BPD Data"
         ],
         "url": "https://data.boston.gov/dataset",
@@ -1810,7 +1810,7 @@
         "id": "dataset-165",
         "provider": "Illinois Department of Corrections",
         "title": "Illinois Division of Research and Planning Data",
-        "alt_title":[
+        "alt_title": [
             "IDOC",
             "IDOC Data"
         ],
@@ -1835,7 +1835,7 @@
             "Maryland Temporary Cash Assistance"
         ],
         "url": "http://dhs.maryland.gov/weathering-tough-times/temporary-cash-assistance/",
-        "description": "Temporary Cash Assistance (TCA), Maryland’s Temporary Assistance to Needy Families (TANF) program, provides cash assistance to families with dependent children when available resources do not fully address the family’s needs and while preparing program participants for independence through work."
+        "description": "Temporary Cash Assistance (TCA), Maryland\u2019s Temporary Assistance to Needy Families (TANF) program, provides cash assistance to families with dependent children when available resources do not fully address the family\u2019s needs and while preparing program participants for independence through work."
     },
     {
         "id": "dataset-167",
@@ -1855,7 +1855,7 @@
             "TA"
         ],
         "url": "https://mydss.mo.gov/temporary-assistance",
-        "description": "The Temporary Assistance for Needy Families program, also known as Temporary Assistance (TA), is a program designed to provide cash benefits to low-income families for the household’s children such as clothing, utilities and other services."
+        "description": "The Temporary Assistance for Needy Families program, also known as Temporary Assistance (TA), is a program designed to provide cash benefits to low-income families for the household\u2019s children such as clothing, utilities and other services."
     },
     {
         "id": "dataset-168",
@@ -1865,7 +1865,7 @@
             "UI",
             "Maryland UI",
             "Maryland Unemployment Insurance"
-    ],
+        ],
         "url": "https://www.dllr.state.md.us/employment/unemployment.shtml",
         "description": "UI-related data on employment and unemployment."
     },
@@ -1877,7 +1877,7 @@
             "UI",
             "Missouri UI",
             "Missouri Unemployment Insurance"
-    ],
+        ],
         "url": "https://labor.mo.gov/data",
         "description": "UI-related data on employment and unemployment."
     },
@@ -1889,7 +1889,7 @@
             "QWI",
             "LEHD",
             "Longitudinal Employer-Household Dynamics"
-    ],
+        ],
         "url": "https://lehd.ces.census.gov/data/qwi/",
         "description": "The Quarterly Workforce Indicators (QWI) are a set of economic indicators including employment, job creation, earnings, and other measures of employment flows."
     },
@@ -1916,7 +1916,7 @@
     },
     {
         "id": "dataset-173",
-        "provider":"MDRC",
+        "provider": "MDRC",
         "title": "Urban Change Neighborhood Indicators Database",
         "description": "Contains Urban Change survey of welfare recipients."
     },
@@ -1966,7 +1966,7 @@
     {
         "id": "dataset-177",
         "provider": "Wisconsin Department of Children and Families",
-        "title": "Wisconsin’s Statewide Automated Child Welfare Information System",
+        "title": "Wisconsin\u2019s Statewide Automated Child Welfare Information System",
         "alt_title": [
             "WiSACWIS",
             "eWiSACWIS"
@@ -1985,57 +1985,57 @@
         "description": "The U.S. Department of Labor's Unemployment Insurance (UI) programs provide unemployment benefits to eligible workers who become unemployed through no fault of their own, and meet certain other eligibility requirements."
     },
     {
-    "id": "dataset-179",
-    "provider": "Johns Hopkins University",
-    "title": "Three-City Study",
-    "alt_title": [
-        "Three City Study"
-    ],
-    "url": "http://web.jhu.edu/threecitystudy/images/CharacteristicsReport.pdf",
-    "description": "For each round of data collection, we provide basic information on the demographic, health, welfare, and other social program status, and on the education, labor force, and income characteristics of the families."
+        "id": "dataset-179",
+        "provider": "Johns Hopkins University",
+        "title": "Three-City Study",
+        "alt_title": [
+            "Three City Study"
+        ],
+        "url": "http://web.jhu.edu/threecitystudy/images/CharacteristicsReport.pdf",
+        "description": "For each round of data collection, we provide basic information on the demographic, health, welfare, and other social program status, and on the education, labor force, and income characteristics of the families."
     },
     {
-    "id": "dataset-180",
-    "provider": "Texas Health and Human Services Commission",
-    "title": "State of Texas Supplemental Nutrition Assistance Program",
-    "alt_title": [
-        "SNAP",
-        "Texas SNAP",
-        "Texas Supplemental Nutrition Assistance Program",
-        "Supplemental Nutrition Assistance Program",
-        "State of Texas SNAP"
-    ],
-    "url": "https://yourtexasbenefits.hhsc.texas.gov/programs/snap",
-    "description": "SNAP offers food benefits to eligible, low-income individuals and families."
+        "id": "dataset-180",
+        "provider": "Texas Health and Human Services Commission",
+        "title": "State of Texas Supplemental Nutrition Assistance Program",
+        "alt_title": [
+            "SNAP",
+            "Texas SNAP",
+            "Texas Supplemental Nutrition Assistance Program",
+            "Supplemental Nutrition Assistance Program",
+            "State of Texas SNAP"
+        ],
+        "url": "https://yourtexasbenefits.hhsc.texas.gov/programs/snap",
+        "description": "SNAP offers food benefits to eligible, low-income individuals and families."
     },
     {
-    "id": "dataset-181",
-    "provider": "Illinois Department of Human Services",
-    "title": "State of Illinois Supplemental Nutrition Assistance Program",
-    "alt_title": [
-        "SNAP",
-        "Illinois SNAP",
-        "Illinois Supplemental Nutrition Assistance Program",
-        "Supplemental Nutrition Assistance Program",
-        "State of Illinois SNAP"
-    ],
-    "url": "https://www.dhs.state.il.us/page.aspx?item=30357",
-    "description": "SNAP offers food benefits to eligible, low-income individuals and families."
+        "id": "dataset-181",
+        "provider": "Illinois Department of Human Services",
+        "title": "State of Illinois Supplemental Nutrition Assistance Program",
+        "alt_title": [
+            "SNAP",
+            "Illinois SNAP",
+            "Illinois Supplemental Nutrition Assistance Program",
+            "Supplemental Nutrition Assistance Program",
+            "State of Illinois SNAP"
+        ],
+        "url": "https://www.dhs.state.il.us/page.aspx?item=30357",
+        "description": "SNAP offers food benefits to eligible, low-income individuals and families."
     },
     {
-    "id": "dataset-182",
-    "provider": "Illinois Department of Human Services",
-    "title": "Illinois Temporary Assitance for Needy Families",
-    "alt_title": [
-        "TANF",
-        "Illinois TANF",
-        "Temporary Assitance for Needy Families",
-        "Aid to Dependent Families with Children",
-        "Illinois Aid to Dependent Families with Children",
-        "Illinois AFDC",
-        "AFDC"
-    ],
-    "url": "https://www.dhs.state.il.us/page.aspx?item=30358",
-    "description": "Temporary Assistance for Needy Families (TANF) provides temporary cash for families in need."
-  }
-  ]
+        "id": "dataset-182",
+        "provider": "Illinois Department of Human Services",
+        "title": "Illinois Temporary Assitance for Needy Families",
+        "alt_title": [
+            "TANF",
+            "Illinois TANF",
+            "Temporary Assitance for Needy Families",
+            "Aid to Dependent Families with Children",
+            "Illinois Aid to Dependent Families with Children",
+            "Illinois AFDC",
+            "AFDC"
+        ],
+        "url": "https://www.dhs.state.il.us/page.aspx?item=30358",
+        "description": "Temporary Assistance for Needy Families (TANF) provides temporary cash for families in need."
+    }
+]


### PR DESCRIPTION
Adding unit test to catch two potential errors:

  - badly formed IDs
  - trailing or leading spaces in `title` or `provider`

Also, this commit applies `cat datasets.json | python -m json.tool` so that the resulting JSON is "pretty-print" formatted with canonical spacing, according to the JSON spec.  It's a minor nit, but we can do that periodically to keep the source data in good shape :)