### PR TITLE
updates for missing datasets

### DIFF
--- a/datasets.json
+++ b/datasets.json
@@ -1309,6 +1309,48 @@
         "description": "Temporary Assistance for Needy Families (TANF) provides temporary cash for families in need."
     },
     {
+    "id": "dataset-111",
+    "provider": "Pennsylvania Department of Human Services",
+    "title": "Transitional Work Corporation",
+    "alt_title": [
+        "Philadelphia Transitional Work Corporation",
+        "TWC"
+    ],
+    "url": "http://nationalinitiatives.issuelab.org/resources/16855/16855.pdf",
+    "description": "The primary relationship for participants in the Transitional Work Corporation’s Program, Philadelphia@Work (P@W), is with a Career Advisor. The Career Advisor will guide the participant through the transitional work experience and provide continued support through the first six months of permanent employment."
+    },
+
+    {
+    "id": "dataset-114",
+    "provider": "Mississippi Department of Human Services",
+    "title": "Mississippi Temporary Assistance to Needy Families",
+    "alt_title": [
+        "TANF",
+        "Mississippi TANF",
+        "Temporary Assistance to Needy Families",
+        "Aid to Dependent Families with Children",
+        "Mississippi Aid to Dependent Families with Children",
+        "Mississippi AFDC",
+        "AFDC"
+    ],
+    "url": "https://www.mdhs.ms.gov/economic-assistance/tanf/",
+    "description": "The TANF Program provides benefits for families with needy children under age 18. The TANF Program is designed to help needy families achieve self-sufficiency through employment and training activities provided by the TANF Work Program (TWP). TANF supportive services such as assistance with child care and transportation expenses are available to help the adults in the family prepare for employment and to promote self-sufficiency."
+    },
+    {
+    "id": "dataset-115",
+    "provider": "Mississippi Department of Human Services",
+    "title": "State of Mississippi Supplemental Nutrition Assistance Program",
+    "alt_title": [
+        "SNAP",
+        "Mississippi SNAP",
+        "Mississippi Supplemental Nutrition Assistance Program",
+        "Supplemental Nutrition Assistance Program",
+        "State of Mississippi SNAP"
+    ],
+    "url": "https://fred.stlouisfed.org/series/BRMS28M647NCEN",
+    "description": "SNAP offers food benefits to eligible, low-income individuals and families."
+},
+    {
         "id": "dataset-116",
         "provider": "Mississippi Department of Employment Services",
         "title": "Mississippi Unemployment Insurance",


### PR DESCRIPTION
Hey Ben
There were some datasets missing in chapin hall partitions (datasets 111-115). I'm assigning you to this PR so you can review the change and verify that they should be in there and weren't deleted for a reason.

I tracked down when they were deleted, see [here](https://github.com/NYU-CI/RCDatasets/commit/b77885296d31f7bd65beeeddaf1baa1d00430d50#diff-651c2a191474468b0ef6776dc60c5d49). I wasn't clear on why these were deleted at the time, but I put them back (except for 113 - it was a dupe 75; and 112 - a dupe was later created in  dataset-274. I updated the linkages in here https://github.com/NYU-CI/RichContextMetadata/blob/master/metadata/20190923_chapinhall/publication_dataset_linkages.csv) for those rows. I will update the partition for that file as well. Thanks!
