### PR TITLE
moved SESTAT as alt_title from SED to SDR

### DIFF
--- a/datasets.json
+++ b/datasets.json
@@ -4335,8 +4335,7 @@
     },
     {
         "alt_title": [
-            "SED",
-            "SESTAT"
+            "SED"
         ],
         "description": "The Survey of Earned Doctorates (SED) gathers information annually from approximately 50,000 new research doctorate graduates from U.S. universities about their educational histories, funding sources, and post-doctoral plans.",
         "id": "dataset-370",
@@ -4378,7 +4377,8 @@
     },
     {
         "alt_title": [
-            "SDR"
+            "SDR",
+            "SESTAT"
         ],
         "description": "The Survey of Doctorate Recipients (SDR) provides demographic, education, and career history information from individuals with a U.S. research doctoral degree in a science, engineering, or health (SEH) field.",
         "id": "dataset-371",


### PR DESCRIPTION
moved SESTAT as alt_title from SED to SDR, according to this https://www.nsf.gov/statistics/sestat/#sestat-landing