### PR TITLE
adding an optional field for comments

### DIFF
--- a/test.py
+++ b/test.py
@@ -27,7 +27,8 @@ class TestVerifyDatasets (unittest.TestCase):
             "title",
             "ror",
             "url",
-            "parent"
+            "parent",
+            "comments"
             ])
 
     DATASETS_ALLOWED_FIELDS = set([
@@ -40,7 +41,8 @@ class TestVerifyDatasets (unittest.TestCase):
             "provider",
             "title",
             "url",
-            "original"
+            "original",
+            "comments"
             ])
 
     PAT_DATASET_ID_FORMAT = re.compile(r"^dataset\-(\d+)$")


### PR DESCRIPTION
@ernestogimeno okay, now this supports adding a `"comments":` field in either providers or datasets